### PR TITLE
Add settings modal and timer integration

### DIFF
--- a/electron-pomodoro-overlay/src/renderer-ui.js
+++ b/electron-pomodoro-overlay/src/renderer-ui.js
@@ -4,6 +4,16 @@ window.addEventListener('DOMContentLoaded', () => {
   const startBtn = document.getElementById('start');
   const pauseBtn = document.getElementById('pause');
   const resetBtn = document.getElementById('reset');
+
+  const settingsBtn = document.getElementById('btn-settings');
+  const settingsModal = document.getElementById('settings-modal');
+  const inputWork = document.getElementById('cfg-work');
+  const inputShort = document.getElementById('cfg-short');
+  const inputLong = document.getElementById('cfg-long');
+  const inputCycles = document.getElementById('cfg-cycles');
+  const cancelBtn = document.getElementById('cfg-cancel');
+  const saveBtn = document.getElementById('cfg-save');
+
   const timerDisplay = document.getElementById('timer');
 
   function updateDisplay(time) {
@@ -11,6 +21,50 @@ window.addEventListener('DOMContentLoaded', () => {
     const seconds = time % 60;
     timerDisplay.textContent = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
   }
+
+  function openModal() {
+    if (settingsModal) settingsModal.style.display = 'block';
+  }
+
+  function closeModal() {
+    if (settingsModal) settingsModal.style.display = 'none';
+  }
+
+  function loadConfig() {
+    const defaults = { work: 25, short: 5, long: 15, cycles: 4 };
+    let cfg = { ...defaults };
+    const stored = localStorage.getItem('pomodoroCfg');
+    if (stored) {
+      try {
+        cfg = { ...cfg, ...JSON.parse(stored) };
+      } catch {}
+    }
+    if (inputWork) inputWork.value = cfg.work;
+    if (inputShort) inputShort.value = cfg.short;
+    if (inputLong) inputLong.value = cfg.long;
+    if (inputCycles) inputCycles.value = cfg.cycles;
+    return cfg;
+  }
+
+  function saveConfig() {
+    const cfg = {
+      work: parseInt(inputWork.value, 10) || 0,
+      short: parseInt(inputShort.value, 10) || 0,
+      long: parseInt(inputLong.value, 10) || 0,
+      cycles: parseInt(inputCycles.value, 10) || 0,
+    };
+    localStorage.setItem('pomodoroCfg', JSON.stringify(cfg));
+    if (typeof applyConfig === 'function') {
+      applyConfig(cfg);
+    } else if (window.applyConfig) {
+      window.applyConfig(cfg);
+    }
+    closeModal();
+  }
+
+  if (settingsBtn) settingsBtn.addEventListener('click', openModal);
+  if (cancelBtn) cancelBtn.addEventListener('click', closeModal);
+  if (saveBtn) saveBtn.addEventListener('click', saveConfig);
 
   if (closeBtn) closeBtn.addEventListener('click', () => window.electronAPI.closeApp());
   if (minBtn) minBtn.addEventListener('click', () => window.electronAPI.minimizeApp());
@@ -20,10 +74,15 @@ window.addEventListener('DOMContentLoaded', () => {
 
   window.electronAPI.onTimerUpdate(updateDisplay);
   window.electronAPI.onTimerFinished(() => {
-    // Optional: show notification or visual feedback
-    updateDisplay(25 * 60); // Reset display to 25:00
+    updateDisplay(25 * 60);
   });
 
-  // Initialize display
+  const cfg = loadConfig();
+  if (typeof applyConfig === 'function') {
+    applyConfig(cfg);
+  } else if (window.applyConfig) {
+    window.applyConfig(cfg);
+  }
+
   updateDisplay(25 * 60);
 });


### PR DESCRIPTION
## Summary
- implement config loading & saving to `localStorage`
- expose modal open/close helpers and bind to buttons
- wire buttons to timer IPC API
- load configuration and apply on start

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873affff8a0832a939518c96b67acb8